### PR TITLE
Remove trailing comma breaking a clean install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm packages, you may install them with:
     
 or 
 
-    npm install minimist xmlhttprequest entities
+    npm install minimist xmlhttprequest entities iconv-lite
 
 ## Warning ##
 

--- a/env/wscript.js
+++ b/env/wscript.js
@@ -468,7 +468,7 @@ MSXML2_XMLHTTP = function() {
         if (typeof _download !== 'undefined') {
             xhr.send(a);
         } else {
-            util_log(this._name + " Not sending data, if you want to interract with remote server, set --down=y");
+            util_log(this._name + " Not sending data, if you want to interact with remote server, set --down=y");
             var s = ''
             for(var ii = 0; ii < 10000; ii++) {
                 s += 'a';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "entities": "^1.1.1",
     "iconv-lite": "^0.4.13",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.0"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
npm install fails otherwise:

```
npm ERR! Failed to parse json
npm ERR! Trailing comma in object at 14:3
npm ERR!   },
npm ERR!   ^
```
