### PR TITLE
Save _Function_calls to files in output directory

### DIFF
--- a/jailme.js
+++ b/jailme.js
@@ -399,6 +399,16 @@ var dump_sandbox = function() {
                 writeFile(fname, p[key]["report_catch"]);
             }
         }
+
+        p = sandbox._Function_calls;
+        for (let key in p) {
+            if (p.hasOwnProperty(key)) {
+                fname = config.save_files + key + ".js";
+                util_log("Saving: " + fname);
+                writeFile(fname, p[key][p[key].length - 1]);
+            }
+        }
+
         var name, p, fname;
         p = sandbox._wscript_saved_files;
         for (let key in p) {


### PR DESCRIPTION
Simple Pull Request in order to treat _Function_calls like evals and save them to disk in the output directory.

This makes it easier to get back these unobfuscated scripts.