### PR TITLE
WriteLine should add \r\n to content

### DIFF
--- a/env/wscript.js
+++ b/env/wscript.js
@@ -166,7 +166,7 @@ TextStream = function(filename) {
     util_log("new " + this._name);
     this.writeline = function(s) {
         util_log(this._name + ".WriteLine(" + _truncateOutput(s) + ")");
-        this._content += s;
+        this._content += s + '\r\n';
         _wscript_saved_files[this._filename] = this._content;
         FS.writeFile(this._filename, this._content);
     }


### PR DESCRIPTION
The real WriteLine ends lines with \r\n.

We should maintain this behavior in order for file hashes to be correct.